### PR TITLE
modification in nav bar, margin, and style

### DIFF
--- a/drink.html
+++ b/drink.html
@@ -29,7 +29,7 @@
     </style>
 </head>
 <body>
-    <div id="drink-page" class="vh-100 d-flex justify-content-start align-items-center flex-column">
+    <div id="drink-page" class="d-flex justify-content-start align-items-center flex-column">
         <!-- ナビゲーション -->
         <nav class="navbar navbar-expand-lg navbar-light bg-light col-12">
             <div class="container-fluid">
@@ -40,32 +40,32 @@
                 <div class="collapse navbar-collapse nothing-you-could-do" id="navbarSupportedContent">
                     <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                     <li class="nav-item">
-                        <a class="nav-link active" aria-current="page" href="index.html">Home</a>
+                        <a class="nav-link" href="index.html">Home</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="drink.html">Drink</a>
+                        <a class="nav-link active" aria-current="page" href="drink.html">Drink</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="sweets.html">Sweets</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="#">Food</a>
+                        <a class="nav-link" href="food.html">Food</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="#">Information</a>
+                        <a class="nav-link" href="sweets.html">Information</a>
                     </li>
                     </ul>
                 </div>
             </div>
         </nav>
         <!-- ドリンク用コンテナ -->
-        <div>
+        <div class="py-5">
             <!-- ホットコーヒー -->
             <div>
-                <h3 class="nothing-you-could-do fs-1">Coffee</h3>
+                <h2 class="nothing-you-could-do fs-1">Coffee</h2>
                 <div class="container">
-                    <div class="row">
-                        <div class="col-12 col-md-6 col-lg-4">
+                    <div class="row justify-content-center">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/brend_hot.jpg" alt="ラムダブレンド" class="img-fluid">
@@ -73,7 +73,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">ラムダブレンド</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/americano_hot.jpg" alt="アメリカーノ" class="img-fluid">
@@ -81,7 +81,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">アメリカーノ</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/latte_hot.jpg" alt="カフェラテ" class="img-fluid">
@@ -89,7 +89,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">カフェラテ</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/cappuccino_hot.jpg" alt="カプチーノ" class="img-fluid">
@@ -97,7 +97,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">カプチーノ</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/espresso.jpg" alt="エスプレッソ" class="img-fluid">
@@ -109,11 +109,11 @@
                 </div>
             </div>
             <!-- アイスコーヒー -->
-            <div class="mt-3">
-                <h3 class="nothing-you-could-do fs-1">Iced Coffee</h3>
+            <div>
+                <h2 class="nothing-you-could-do fs-1">Iced Coffee</h2>
                 <div class="container">
-                    <div class="row">
-                        <div class="col-12 col-md-6 col-lg-4">
+                    <div class="row justify-content-center">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/brend_cold.jpg" alt="ラムダブレンド" class="img-fluid">
@@ -121,7 +121,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">ラムダブレンド</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/americano_cold.jpg" alt="アメリカーノ" class="img-fluid">
@@ -129,7 +129,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">アメリカーノ</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/latte_cold.jpg" alt="カフェラテ" class="img-fluid">
@@ -137,7 +137,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">カフェラテ</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/cappuccino_cold.jpg" alt="カプチーノ" class="img-fluid">
@@ -145,7 +145,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">カプチーノ</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/espresso_cold.jpg" alt="エスプレッソ" class="img-fluid">
@@ -157,11 +157,11 @@
                 </div>
             </div>
             <!-- 紅茶 -->
-            <div class="mt-3">
-                <h3 class="nothing-you-could-do fs-1">Tea</h3>
+            <div>
+                <h2 class="nothing-you-could-do fs-1">Tea</h2>
                 <div class="container">
-                    <div class="row">
-                        <div class="col-12 col-md-6 col-lg-4">
+                    <div class="row justify-content-center">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/tea_hot.jpg" alt="ホットティー ストレート" class="img-fluid">
@@ -169,7 +169,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">ホットティー ストレート</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/milk_tea_hot.jpg" alt="ホットティー ミルク" class="img-fluid">
@@ -177,7 +177,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">ホットティー ミルク</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/lemon_tea_hot.jpg" alt="ホットティー レモン" class="img-fluid">
@@ -185,7 +185,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">ホットティー レモン</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/tea_cold.jpg" alt="アイスティー ストレート" class="img-fluid">
@@ -193,7 +193,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">アイスティー ストレート</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/milk_tea_cold.jpg" alt="アイスティー ミルク" class="img-fluid">
@@ -201,7 +201,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">アイスティー ミルク</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/lemon_team_cold.jpg" alt="アイスティー レモン" class="img-fluid">
@@ -213,11 +213,11 @@
                 </div>
             </div>
             <!-- その他 -->
-            <div class="mt-3">
-                <h3 class="nothing-you-could-do fs-1">Others</h3>
+            <div>
+                <h2 class="nothing-you-could-do fs-1">Others</h2>
                 <div class="container">
-                    <div class="row">
-                        <div class="col-12 col-md-6 col-lg-4">
+                    <div class="row justify-content-center">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/milk.jpg" alt="ミルク" class="img-fluid">
@@ -225,7 +225,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">ミルク</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/hot_chocolate.jpg" alt="ホットチョコレート" class="img-fluid">
@@ -233,7 +233,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">ホットチョコレート</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="drink_images/orange_juice.jpg" alt="オレンジジュース" class="img-fluid">
@@ -246,5 +246,13 @@
             </div>
         </div>
     </div>
+
+    <!--Fotter-->
+    <footer class="py-4 text-center text-muted">
+        <small>&copy; Cafe Recursion</small>
+    </footer>
+
+    <!-- Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/sweets.html
+++ b/sweets.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Caffe Recursionのドリンクページです。">
+    <meta name="description" content="Caffe Recursionのスイーツページです。">
     <!-- Destyle CSS -->
     <link rel="stylesheet" href="styles/destyle.css">
     <!-- Bootstrap CSS -->
@@ -19,7 +19,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Hina+Mincho&display=swap" rel="stylesheet">
     <!-- Title -->
     <title>Sweets | Cafe Recursion</title>
-    <!-- メニュー名のフォント用 (複数ファイルで重複するから、最後にstyle.cssに記述する) -->
+    <!-- メニュー名のフォント用 -->
     <style>
         .hina-mincho-regular {
             font-family: "Hina Mincho", serif;
@@ -29,7 +29,7 @@
     </style>
 </head>
 <body>
-    <div id="drink-page" class="vh-100 d-flex justify-content-start align-items-center flex-column">
+    <div id="drink-page" class="d-flex justify-content-start align-items-center flex-column">
         <!-- ナビゲーション -->
         <nav class="navbar navbar-expand-lg navbar-light bg-light col-12">
             <div class="container-fluid">
@@ -40,32 +40,32 @@
                 <div class="collapse navbar-collapse nothing-you-could-do" id="navbarSupportedContent">
                     <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                     <li class="nav-item">
-                        <a class="nav-link active" aria-current="page" href="index.html">Home</a>
+                        <a class="nav-link" href="index.html">Home</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="drink.html">Drink</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="sweets.html">Sweets</a>
+                        <a class="nav-link active" aria-current="page" href="sweets.html">Sweets</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="#">Food</a>
+                        <a class="nav-link" href="food.html">Food</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="#">Information</a>
+                        <a class="nav-link" href="information.html">Information</a>
                     </li>
                     </ul>
                 </div>
             </div>
         </nav>
         <!-- スイーツ用コンテナ -->
-        <div>
+        <div class="py-5">
             <!-- ソフトクリーム -->
             <div>
-                <h3 class="nothing-you-could-do fs-1">Soft Serve Ice Cream</h3>
+                <h2 class="nothing-you-could-do fs-1">Soft Serve Ice Cream</h2>
                 <div class="container">
-                    <div class="row">
-                        <div class="col-12 col-md-6 col-lg-4">
+                    <div class="row justify-content-center">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="sweets_images/milk_softcream.jpg" alt="ミルク" class="img-fluid">
@@ -73,7 +73,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">ミルク</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="sweets_images/mocha_softcream.jpg" alt="モカ" class="img-fluid">
@@ -81,7 +81,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular" class="img-fluid">モカ</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="sweets_images/mixed_softcream.jpg" alt="ミックス" class="img-fluid">
@@ -93,11 +93,11 @@
                 </div>
             </div>
             <!-- ケーキ -->
-            <div class="mt-3">
-                <h3 class="nothing-you-could-do fs-1">Cake</h3>
+            <div>
+                <h2 class="nothing-you-could-do fs-1">Cake</h2>
                 <div class="container">
-                    <div class="row">
-                        <div class="col-12 col-md-6 col-lg-4">
+                    <div class="row justify-content-center">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="sweets_images/cheesecake.jpg" alt="チーズケーキ" class="img-fluid">
@@ -105,7 +105,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">チーズケーキ</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="sweets_images/shortcake.jpg" alt="ショートケーキ" class="img-fluid">
@@ -113,7 +113,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">ショートケーキ</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="sweets_images/mont_blanc.jpg" alt="モンブラン" class="img-fluid">
@@ -125,11 +125,11 @@
                 </div>
             </div>
             <!-- プリン & ティラミス -->
-            <div class="mt-3">
-                <h3 class="nothing-you-could-do fs-1">Pudding & Tiramisù</h3>
+            <div>
+                <h2 class="nothing-you-could-do fs-1">Pudding & Tiramisù</h2>
                 <div class="container">
-                    <div class="row">
-                        <div class="col-12 col-md-6 col-lg-4">
+                    <div class="row justify-content-center">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="sweets_images/pudding.jpg" alt="プリン" class="img-fluid">
@@ -137,7 +137,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">プリン</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="sweets_images/pudding_a_la_mode.jpg" alt="プリン・ア・ラモード" class="img-fluid">
@@ -145,7 +145,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">プリン・ア・ラモード</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="sweets_images/tiramisu.jpg" alt="ティラミス" class="img-fluid">
@@ -153,7 +153,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">ティラミス</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="sweets_images/pudding_and_tiramisu.jpg" alt="プリン・ティラミスセット" class="img-fluid">
@@ -165,11 +165,11 @@
                 </div>
             </div>
             <!-- その他 -->
-            <div class="mt-3">
-                <h3 class="nothing-you-could-do fs-1">Others</h3>
+            <div>
+                <h2 class="nothing-you-could-do fs-1">Others</h2>
                 <div class="container">
-                    <div class="row">
-                        <div class="col-12 col-md-6 col-lg-4">
+                    <div class="row justify-content-center">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="sweets_images/fruit_tart.jpg" alt="フルーツタルト" class="img-fluid">
@@ -177,7 +177,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">フルーツタルト</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="sweets_images/apple_pie.jpg" alt="アップルパイ" class="img-fluid">
@@ -185,7 +185,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">アップルパイ</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="sweets_images/coffee_jelly.jpg" alt="コーヒーゼリー" class="img-fluid">
@@ -193,7 +193,7 @@
                                 <p class="text-center fs-3 hina-mincho-regular">コーヒーゼリー</p>
                             </div>
                         </div>
-                        <div class="col-12 col-md-6 col-lg-4">
+                        <div class="col-12 col-md-6 col-lg-4 mb-5">
                             <div>
                                 <div>
                                     <img src="sweets_images/banana_parfait.jpg" alt="バナナパフェ" class="img-fluid">
@@ -206,5 +206,13 @@
             </div>
         </div>
     </div>
+
+    <!--Fotter-->
+    <footer class="py-4 text-center text-muted">
+        <small>&copy; Cafe Recursion</small>
+    </footer>
+
+    <!-- Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## 概要
ミーティングの際に上がった修正を行いました。

## やったこと
Issueに書いてあるように、以下の修正を行いました。
- drink.htmlとsweet.htmlのハンバーガーメニューを開けるようにする
- ナビゲーションのリンクの追加
- スタイルをfood.htmlとinformation.htmlと統一する
- マージンの調整

## 画像
### drink.html
#### ハンバーガーメニュー → ドロップダウン
<img width="1170" height="871" alt="スクリーンショット 2025-10-31 221821" src="https://github.com/user-attachments/assets/10a25d66-07e4-4808-b709-111e69a8a066" />

#### justify-content-centerに変更
<img width="1170" height="863" alt="スクリーンショット 2025-10-31 221957" src="https://github.com/user-attachments/assets/98f56b3f-e22e-4bcd-810f-54bc2f34266e" />


### sweets.html
#### ハンバーガーメニュー → ドロップダウン
<img width="1173" height="865" alt="image" src="https://github.com/user-attachments/assets/462b110b-6bf2-4cb5-a63b-c0bb2b3d5925" />

#### justify-content-centerに変更
<img width="1178" height="864" alt="スクリーンショット 2025-10-31 222333" src="https://github.com/user-attachments/assets/324f91c9-737b-4cd9-aa1b-61fc5aa7bbd3" />
