### PR TITLE
Fix/navbar sweets link

### DIFF
--- a/food.html
+++ b/food.html
@@ -43,7 +43,7 @@
             <a class="nav-link" href="drink.html">Drink</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#">Sweets</a>
+            <a class="nav-link" href="sweets.html">Sweets</a>
           </li>
           <li class="nav-item">
             <a class="nav-link active" aria-current="page" href="food.html">Food</a>

--- a/information.html
+++ b/information.html
@@ -42,7 +42,7 @@
           <a class="nav-link" href="drink.html">Drink</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="#">Sweets</a>
+          <a class="nav-link" href="sweets.html">Sweets</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="food.html">Food</a>


### PR DESCRIPTION
- Updated navbar Sweets link from "#" to "sweets.html" in food.html and information.html
- Ensures navigation works across pages